### PR TITLE
Cleanup obsolete data fields

### DIFF
--- a/templates/metrics.schema.json
+++ b/templates/metrics.schema.json
@@ -32,9 +32,6 @@
           },
           "unhealthyOperator": {
             "type": "string"
-          },
-          "dataUnit": {
-            "type": "string"
           }
         },
         "required": [
@@ -44,8 +41,7 @@
           "degradedThreshold",
           "degradedOperator",
           "unhealthyThreshold",
-          "unhealthyOperator",
-          "dataUnit"
+          "unhealthyOperator"
         ]
       }
     ]

--- a/templates/metrics.schema.json
+++ b/templates/metrics.schema.json
@@ -3,8 +3,6 @@
     "type": "array",
     "additionalItems": true,
     "additionalProperties": {
-        "reference": "string",
-        "description": "string",
         "recommended": "string"
     },
     "minItems": 1,

--- a/templates/microsoft.cache/redis/metrics.json
+++ b/templates/microsoft.cache/redis/metrics.json
@@ -9,7 +9,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "85",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     },
     {
@@ -22,7 +21,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "85",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     },
     {
@@ -35,7 +33,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "20",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Count",
         "recommended": "true"
     }
 ]

--- a/templates/microsoft.cache/redis/metrics.json
+++ b/templates/microsoft.cache/redis/metrics.json
@@ -1,8 +1,6 @@
 [
     {
         "metricName": "serverLoad",
-        "description": "Server load of the Redis cache.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Average",
         "timeGrain": "PT30M",
         "degradedThreshold": "75",
@@ -13,8 +11,6 @@
     },
     {
         "metricName": "usedmemorypercentage",
-        "description": "Percentage of used memory of the Redis cache.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Average",
         "timeGrain": "PT30M",
         "degradedThreshold": "75",
@@ -25,8 +21,6 @@
     },
     {
         "metricName": "errors",
-        "description": "Number of errors of the Redis cache.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Average",
         "timeGrain": "PT1H",
         "degradedThreshold": "10",

--- a/templates/microsoft.compute/virtualmachines/metrics.json
+++ b/templates/microsoft.compute/virtualmachines/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "90",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     }
 ]

--- a/templates/microsoft.containerservice/managedclusters/metrics.json
+++ b/templates/microsoft.containerservice/managedclusters/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "85",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     },
     {
@@ -18,7 +17,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "90",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
      }
 ]

--- a/templates/microsoft.documentdb/databaseaccounts/metrics.json
+++ b/templates/microsoft.documentdb/databaseaccounts/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "95",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Percent",
         "recommended": "true"
      }
 ]

--- a/templates/microsoft.eventhub/namespaces/metrics.json
+++ b/templates/microsoft.eventhub/namespaces/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "10",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Count",
         "recommended": "true"
      }
 ]

--- a/templates/microsoft.keyvault/vaults/metrics.json
+++ b/templates/microsoft.keyvault/vaults/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "95",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     },
     {
@@ -18,7 +17,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "50",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "Percent",
         "recommended": "true"
      },
      {
@@ -28,7 +26,6 @@
         "degradedThreshold": "50",
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "100",
-        "unhealthyOperator": "GreaterThan",
-        "dataUnit": "MilliSeconds"
+        "unhealthyOperator": "GreaterThan"
      }
 ]

--- a/templates/microsoft.network/loadbalancers/metrics.json
+++ b/templates/microsoft.network/loadbalancers/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "95",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Count",
         "recommended": "true"
      },
      {
@@ -18,7 +17,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "95",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Count",
         "recommended": "true"
      }
 ]

--- a/templates/microsoft.network/publicipaddresses/metrics.json
+++ b/templates/microsoft.network/publicipaddresses/metrics.json
@@ -7,7 +7,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "95",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Count",
         "recommended": "true"
      }
 ]

--- a/templates/microsoft.storage/storageaccounts/metrics.json
+++ b/templates/microsoft.storage/storageaccounts/metrics.json
@@ -1,8 +1,6 @@
 [
     {
         "metricName": "Availability",
-        "description": "Availability of a storage account.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Minimum",
         "timeGrain": "PT15M",
         "degradedThreshold": "100",
@@ -13,8 +11,6 @@
     },
     {
         "metricName": "SuccessE2ELatency",
-        "description": "SuccessE2ELatency of a storage account.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Average",
         "timeGrain": "PT5M",
         "degradedThreshold": "10",
@@ -25,8 +21,6 @@
     },
     {
         "metricName": "SuccessServerLatency",
-        "description": "SuccessServerLatency of a storage account.",
-        "reference": "https://link/to/more/information",
         "aggregationType": "Average",
         "timeGrain": "PT5M",
         "degradedThreshold": "10",

--- a/templates/microsoft.storage/storageaccounts/metrics.json
+++ b/templates/microsoft.storage/storageaccounts/metrics.json
@@ -9,7 +9,6 @@
         "degradedOperator": "LowerThan",
         "unhealthyThreshold": "99",
         "unhealthyOperator": "LowerThan",
-        "dataUnit": "Percent",
         "recommended": "true"
     },
     {
@@ -22,7 +21,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "15",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "MilliSeconds",
         "recommended": "false"
     },
     {
@@ -35,7 +33,6 @@
         "degradedOperator": "GreaterThan",
         "unhealthyThreshold": "15",
         "unhealthyOperator": "GreaterThan",
-        "dataUnit": "MilliSeconds",
         "recommended": "false"
     }
 ]


### PR DESCRIPTION
This PR removes `dataUnit`, `description` and `reference` as these values are currently either not used or provided via the Azure Metrics API. Do not merge before the changes for the portal extension have been merged and rolled out to canary and prod.